### PR TITLE
Produce and publish sources jar

### DIFF
--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -23,10 +23,17 @@ compileTestKotlin {
     kotlinOptions.jvmTarget = "1.8"
 }
 
+task sourcesJar(type: Jar, dependsOn: classes) {
+    archiveClassifier.set('sources')
+    from sourceSets.main.allSource
+}
+
 publishing {
     publications {
         mavenJava(MavenPublication) {
             from components.java
+
+            artifact sourcesJar
         }
     }
 }


### PR DESCRIPTION
This allows us to debug the library code from app project without needing to move sources.